### PR TITLE
Set encrypt vault id to default explicitly

### DIFF
--- a/ftplugin/yaml/vim_vault_inline.py
+++ b/ftplugin/yaml/vim_vault_inline.py
@@ -53,10 +53,18 @@ def vault_subshell(string, mode):
             print("Cannot find `ansible-vault` in PATH!")
             return
 
-        vault_command = (
-            'ansible-vault', mode, '-',
-            '--vault-password-file', pass_fn
-        )
+        if mode == MODE_ENCRYPT:
+            vault_command = (
+                'ansible-vault', mode, '-',
+                '--encrypt-vault-id', 'default',
+                '--vault-password-file', pass_fn
+            )
+        else:
+            vault_command = (
+                'ansible-vault', mode, '-',
+                '--vault-password-file', pass_fn
+            )
+
         vault = subprocess.Popen(vault_command,
                                  stdin=subprocess.PIPE,
                                  stdout=subprocess.PIPE)

--- a/ftplugin/yaml/vim_vault_inline.py
+++ b/ftplugin/yaml/vim_vault_inline.py
@@ -46,7 +46,8 @@ def next_line(line_num):
 
 
 def vault_subshell(string, mode):
-    pass_fn = os.getenv("VAULT_PASSWORD_FILE")
+    pass_fn = os.getenv("VAULT_PASSWORD_FILE") or os.getenv("ANSIBLE_VAULT_PASSWORD_FILE")
+
     if pass_fn:
         pass_fn = os.path.expanduser(pass_fn)
         if not spawn.find_executable("ansible-vault"):
@@ -75,7 +76,7 @@ def vault_subshell(string, mode):
         else:
             print("Could not encrypt value.")
     else:
-        print("Please set 'VAULT_PASSWORD_FILE' in your environment.")
+        print("Please set 'ANSIBLE_VAULT_PASSWORD_FILE' or 'VAULT_PASSWORD_FILE' in your environment.")
 
 
 class VaultHandler(object):


### PR DESCRIPTION
Fixes an issue when multiple vaults are provided, e.g, one as a commandline argument and another as an env variable